### PR TITLE
Fix missing options for GtChecklistStatus 

### DIFF
--- a/Templates/Content-Anlegg/Prosjektmaler/Anlegg.txt
+++ b/Templates/Content-Anlegg/Prosjektmaler/Anlegg.txt
@@ -691,9 +691,6 @@
             "AdditionalSettings": {
                 "EnableVersioning": true
             },
-            "Fields": [
-                "<Field ID=\"{249527a3-c7f9-4ea5-9c33-f942c06c9215}\" Type=\"Choice\" Name=\"GtChecklistStatus\" StaticName=\"GtChecklistStatus\" DisplayName=\"Status\" Description=\"Hva er statusen for sjekkpunktet? (Anbefalt status = 'Åpen'. Dette påvirker om man blir etterspurt sjekkpunktet ifm faseendring)\" />"
-            ],
             "Views": [
                 {
                     "Title": "Alle elementer",

--- a/Templates/Content-Bygg/Prosjektmaler/Bygg.txt
+++ b/Templates/Content-Bygg/Prosjektmaler/Bygg.txt
@@ -691,9 +691,6 @@
             "AdditionalSettings": {
                 "EnableVersioning": true
             },
-            "Fields": [
-                "<Field ID=\"{249527a3-c7f9-4ea5-9c33-f942c06c9215}\" Type=\"Choice\" Name=\"GtChecklistStatus\" StaticName=\"GtChecklistStatus\" DisplayName=\"Status\" Description=\"Hva er statusen for sjekkpunktet? (Anbefalt status = 'Åpen'. Dette påvirker om man blir etterspurt sjekkpunktet ifm faseendring)\" />"
-            ],
             "Views": [
                 {
                     "Title": "Alle elementer",


### PR DESCRIPTION
This pr will fix issues related to Puzzlepart/prosjektportalen365#484 where a field override in the project json template caused GtChecklistStatus (status in phase checklist) to not have any availiable options

This pr specifically patches
- template Anlegg
- template Bygg
